### PR TITLE
Use hash attribute instead of full href

### DIFF
--- a/src/HashLink.jsx
+++ b/src/HashLink.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 
 function _animateScroll(event, animate) {
   event.preventDefault();
-  const hash = event.target.getAttribute('href');
+  const hash = event.target.hash;
   animateScroll(hash, animate);
 }
 


### PR DESCRIPTION
Allow more than just the hash passed to the href attribute
